### PR TITLE
logo-container min-height: 100% wrong for Firefox formatting

### DIFF
--- a/landing/src/components/logo/logo.css
+++ b/landing/src/components/logo/logo.css
@@ -1,6 +1,5 @@
 .logo-container {
     grid-area: logo;
-    min-height: 100%;
     max-height: 100%;
     min-width: 100%;
     max-width: 100%;


### PR DESCRIPTION
Fixes #60